### PR TITLE
Disable autocomplete for test string inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,7 +140,7 @@
                 </div>
             </div>
             <label ng-repeat="testInput in testInputs">
-                <input type="text" name="{{$index}}" ng-model="testInput.inputString" ng-trim="false" jsflap-test-input="" ng-class="(testInput.result === true || testInput.result === false) ?(testInput.result?'accepted':'rejected'):''" placeholder="Enter test string here">
+                <input type="text" name="{{$index}}" ng-model="testInput.inputString" ng-trim="false" jsflap-test-input="" ng-class="(testInput.result === true || testInput.result === false) ?(testInput.result?'accepted':'rejected'):''" placeholder="Enter test string here" autocomplete="off">
             </label>
             <a class="newTestInput" href="#" ng-click="addTestInput()">Enter test string here</a>
         </form>


### PR DESCRIPTION
While using jsflap for an assignment and typing in test strings, my browser (Safari) kept trying to give me suggestions from previous test strings, all of which consisted of a's and b's. Because of this simple character space, many of my test strings began similarly, but were almost always different, thus the autocomplete list was nothing more than a nuisance.
